### PR TITLE
Fix compatibility for older node/iojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/51Degreesmobi/51degrees.node",
   "dependencies": {
     "debug": "2.1.0",
-    "nan": "2.0.0"
+    "nan": "2.0.9"
   },
   "devDependencies": {
     "csv": "^0.4.0",

--- a/src/pattern/api.cc
+++ b/src/pattern/api.cc
@@ -156,7 +156,7 @@ NAN_METHOD(PatternParser::Parse) {
         else
           Nan::Set(result, keyVal, Nan::New<v8::String>(val).ToLocalChecked());
       } else {
-        MaybeLocal<Array> vals = Nan::New<Array>(ws->valuesCount - 1);
+        Nan::MaybeLocal<Array> vals = Nan::New<Array>(ws->valuesCount - 1);
         for (valueIndex = 0; valueIndex < ws->valuesCount; valueIndex++) {
           const char *val = fiftyoneDegreesGetValueName(ws->dataSet, *(ws->values + valueIndex));
           Nan::Set(vals.ToLocalChecked(), 


### PR DESCRIPTION
The latest update (1.8.0) with the nan module upgrade seems to have broken compatibility with older node/iojs versions.

I made this quick fix, although I am not too familiar with nan and v8 API. (the problem was that v8:MaybeLocal is only available with iojs 3.0+).

I have also updated nan version to the latest one in the process.